### PR TITLE
타입 수정 및 네이밍 분리 (userId, hashedId)

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -12,16 +12,17 @@ const createTimestamp = () => {
 };
 
 export const useYLSLogger = () => {
-  const screen = ({ userId, name }: LogPayloadParams) => {
+  const screen = ({ userId, serviceName, name }: LogPayloadParams) => {
     //사용자에서 userId, name, message(선택) 등을 넣어줌
     const loggerType: LogPayloadParams = {
       userId: userId,
       path: '/',
-      serviceName: 'home',
+      serviceName: serviceName,
       name: '',
       message: '/',
     };
     const logger = Logger(loggerType);
+    console.log(`Logging screen information for screen: ${serviceName}`);
     logger.event.name = name;
   };
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,8 +1,8 @@
-import { LogPayloadParams, LogType, LoggerType } from './types/LogType';
+import { LogPayloadParams } from './types/LogType';
 
-const createUserId = () => {
-  // Todo: create random id
-  return 123;
+const createHashedId = (userId: string) => {
+  // Todo: create hashedId
+  return '';
 };
 
 const createTimestamp = () => {
@@ -11,50 +11,33 @@ const createTimestamp = () => {
   return now.toISOString();
 };
 
-const setLocalStorage = (logger: LogType) => {
-  if (window.localStorage.getItem('yls-web') == undefined) {
-    const list: any[] = [];
-    list.push(logger);
-    localStorage.setItem('yls-web', JSON.stringify(list));
-  } else {
-    const remainList: any[] = JSON.parse(localStorage.getItem('yls-web') as string) || [];
-    const updateList = [...remainList, logger];
-    localStorage.setItem('yls-web', JSON.stringify(updateList));
-  }
-};
-
 export const useYLSLogger = () => {
-  const screen = ({ serviceName, name }: LogPayloadParams) => {
-    //사용자에서 path,name,message를 넣어줌
-    const loggerType: LoggerType = {
+  const screen = ({ userId, name }: LogPayloadParams) => {
+    //사용자에서 userId, name, message(선택) 등을 넣어줌
+    const loggerType: LogPayloadParams = {
+      userId: userId,
       path: '/',
       serviceName: 'home',
       name: '',
       message: '/',
     };
     const logger = Logger(loggerType);
-    console.log(`Logging screen information for path: ${serviceName}`);
     logger.event.name = name;
-
-    setLocalStorage(logger);
   };
 
-  const click = ({ name }: LogPayloadParams) => {
+  const click = ({ userId, name }: LogPayloadParams) => {
+    //사용자에서 userId, name, message(선택) 등을 넣어줌
+    const loggerType: LogPayloadParams = {
+      userId: userId,
+      path: '/',
+      serviceName: 'home',
+      name: '',
+      message: '/',
+    };
+    const logger = Logger(loggerType);
     console.log(`Logging click information for button: ${name}`);
-    //사용자에서 path,name,message를 넣어줌
-    const loggerType: LoggerType = {
-      path: '/',
-      serviceName: 'home',
-      name: '',
-      message: '/',
-    };
-    const logger = Logger(loggerType);
-
     logger.event.name = name;
-
-    setLocalStorage(logger);
   };
-  // todo: 로컬스토리지 로그 개수가 10개 넘어가면 postLog.ts호출
 
   return {
     screen,
@@ -62,9 +45,9 @@ export const useYLSLogger = () => {
   };
 };
 
-export const Logger = ({ serviceName, name, message, path, tags }: LoggerType) => {
+export const Logger = ({ userId, serviceName, name, message, path, tags }: LogPayloadParams) => {
   return {
-    userId: createUserId(),
+    hashedId: createHashedId(userId),
     timestamp: createTimestamp(),
     event: {
       platform: 'web',

--- a/src/demo/Home.tsx
+++ b/src/demo/Home.tsx
@@ -12,16 +12,16 @@ export const Home = () => {
       <div className="card">
         <LogScreen
           params={{
-            userId: 123,
-            screenName: router.pathname,
-            eventName: '',
+            userId: 'test',
+            // serviceName: router.pathname,
+            serviceName: 'drawer', // 임시 값 (로컬 테스트 시 type을 잠시 변경해야 함)
+            name: '',
           }}
         >
           <LogClick
             params={{
-              userId: 123,
-              eventName: 'click',
-              screenName: '',
+              userId: 'test',
+              name: 'click',
             }}
           >
             <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>

--- a/src/types/LogType.ts
+++ b/src/types/LogType.ts
@@ -1,6 +1,6 @@
 // LogType: 최종 Log 형태
 export interface LogType {
-  userId: number;
+  hashedId: string;
   timestamp: string;
   event: {
     platform: string;
@@ -12,18 +12,9 @@ export interface LogType {
   };
 }
 
-// LoggerType: Log 내 event에 들어가는 값
-export interface LoggerType {
-  serviceName: 'drawer' | 'home' | 'search';
-  name: string;
-  message?: string;
-  path?: string;
-  tags?: string[];
-}
-
 // LogPayloadParams: 사용처에서 넣어주는 값
 export interface LogPayloadParams {
-  userId: number;
+  userId: string;
   name: string | '';
   serviceName?: 'drawer' | 'home' | 'search';
   message?: string;


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- 사용처에서 event 내부 값만 보내주는 것이 아닌 userId도 같이 보내주므로 기존에 존재하던 LoggerType(event 내부 값만 취급)을 제거하였습니다.
   - LoggerType을 사용하던 부분은 LogPayloadParams로 통일하였습니다.
- LogPayloadParams(사용처에서 넣어주는 값, 타입) 내부 userId 타입을 number -> string
- LogType(최종 Log 형태)의 기존 userId -> hashedId 네이밍 변경 및 타입 number -> string
- setLocalStorage 로직을 삭제하였습니다.
- 주석도 저번에 얘기 나눈대로 살짝 수정했습니다~!
- demo app에도 수정 사항 반영해뒀습니다.

- resolved #18 

## 3️⃣ 추후 작업

createHashedId 함수 구현

## 4️⃣ 체크리스트 (Checklist)

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
